### PR TITLE
Configurable outage response handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,15 @@ service.end_forced_outage!
 Unlike with outages detected by the middleware, forced outages are not periodically tested to see if they have completed and must be
 manually ended with a call to `end_forced_outage!`.
 
+### Changing the Outage Response
+
+By default, if you make a request against a service that is experiencing an outage a Breakers::OutageException will be raised. If you would
+prefer to receive a response with a certain status code instead, you can change that with:
+
+```ruby
+Breakers.outage_response = { type: :status_code, status_code: 503 }
+```
+
 ### Redis Data Structure
 
 Data is stored in Redis with the following structure:

--- a/lib/breakers.rb
+++ b/lib/breakers.rb
@@ -1,5 +1,6 @@
 require 'breakers/client'
 require 'breakers/outage'
+require 'breakers/outage_exception'
 require 'breakers/service'
 require 'breakers/uptime_middleware'
 require 'breakers/version'
@@ -39,5 +40,22 @@ module Breakers
   # @return [String] the prefix
   def self.redis_prefix
     @redis_prefix || ''
+  end
+
+  # Configure the middleware's handling of outages. The default is to raise a Breakers::OutageException
+  # but you can also request that the response comes back with a configurable status code.
+  #
+  # @param [Hash] opts A hash of options
+  # @option opts [Symbol] :type Pass :exception to raise a Breakers::OutageException when an error occurs. Pass :status_code to respond.
+  # @option opts [Integer] :status_code If the type is :status_code, configure which code to return.
+  def self.outage_response=(opts)
+    @outage_response = { type: :exception }.merge(opts)
+  end
+
+  # Query for the outage response configuration
+  #
+  # @return [Hash] configuration for the outage response, as defined in outage_response=
+  def self.outage_response
+    @outage_response || { type: :exception }
   end
 end

--- a/lib/breakers/outage_exception.rb
+++ b/lib/breakers/outage_exception.rb
@@ -1,0 +1,17 @@
+module Breakers
+  # The error that is raised when a request is made against a service that is
+  # experiencing an outage
+  class OutageException < StandardError
+    attr_reader :outage
+    attr_reader :service
+
+    def initialize(outage, service)
+      @outage = outage
+      @service = service
+    end
+
+    def message
+      "Outage detected on #{@service.name} beginning at #{@outage.start_time.to_i}"
+    end
+  end
+end

--- a/lib/breakers/version.rb
+++ b/lib/breakers/version.rb
@@ -1,3 +1,3 @@
 module Breakers
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.2.0'.freeze
 end


### PR DESCRIPTION
This changes the default response to a query against a service that is experiencing an outage to be raising an exception. The exception is a Breakers::OutageException, which includes information about the outage and service where it happened. It's also configurable so that you can tell it to instead return a response with a configurable status code.
