### PR TITLE
add option to totally disable breakers

### DIFF
--- a/lib/breakers.rb
+++ b/lib/breakers.rb
@@ -25,6 +25,20 @@ module Breakers
     @client
   end
 
+  # Set a flag that can globally disable breakers
+  #
+  # @param value [Boolean] should breakers do its thing globally
+  def self.disabled=(value)
+    @disabled = value
+  end
+
+  # Return the status of global disabling
+  #
+  # @return [Boolean] is breakers disabled globally
+  def self.disabled?
+    defined?(@disabled) && @disabled == true
+  end
+
   # Breakers uses a number of Redis keys to store its data. You can pass an optional
   # prefix here to use for the keys so that they will be namespaced properly. Note that
   # it's also possible to create the Breakers::Client object with a Redis::Namespace

--- a/lib/breakers/uptime_middleware.rb
+++ b/lib/breakers/uptime_middleware.rb
@@ -9,6 +9,10 @@ module Breakers
     end
 
     def call(request_env)
+      if Breakers.disabled?
+        return @app.call(request_env)
+      end
+
       service = Breakers.client.service_for_request(request_env: request_env)
 
       if !service

--- a/lib/breakers/version.rb
+++ b/lib/breakers/version.rb
@@ -1,3 +1,3 @@
 module Breakers
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.2.1'.freeze
 end


### PR DESCRIPTION
Since we're not going to be able to test this under load until we go into production, I'm adding a flag to allow disabling of breakers entirely. This way, if something goes horribly wrong with it then we can make a deploy that simply sets the disabled flag and move on while fixing the problem.
