### PR TITLE
Report the duration of the request in the env

### DIFF
--- a/lib/breakers/uptime_middleware.rb
+++ b/lib/breakers/uptime_middleware.rb
@@ -49,7 +49,9 @@ module Breakers
     end
 
     def handle_request(service:, request_env:, current_outage: nil)
+      start_time = Time.now
       return @app.call(request_env).on_complete do |response_env|
+        response_env[:duration] = Time.now - start_time
         if response_env.status >= 500
           handle_error(
             service: service,

--- a/lib/breakers/version.rb
+++ b/lib/breakers/version.rb
@@ -1,3 +1,3 @@
 module Breakers
-  VERSION = '0.2.1'.freeze
+  VERSION = '0.2.2'.freeze
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -465,4 +465,18 @@ describe 'integration suite' do
       expect { connection.get '/' }.to raise_error(Breakers::OutageException)
     end
   end
+
+  context 'with a 200' do
+    let(:now) { Time.now.utc }
+
+    before do
+      Timecop.freeze(now)
+      stub_request(:get, 'va.gov').to_return(status: 200)
+    end
+
+    it 'gives me the request duration' do
+      response = connection.get '/'
+      expect(response.env[:duration]).to be
+    end
+  end
 end


### PR DESCRIPTION
We have a case where in one of our plugins we would like to know how long a request to a backend service took when it is successful. Since we would like to do that timing per service, being able to report it back from breakers seems ideal. So this adds the request duration to response environment, which the plugin can see.

I feel like this is an extension of breakers beyond what it should really be doing, and that feels a little dirty. But since the extension is so lightweight and it solves a problem that would be a bit of a pain to solve otherwise I think this seems ok.
