### PR TITLE
allow clients to define exception handling

### DIFF
--- a/lib/breakers/service.rb
+++ b/lib/breakers/service.rb
@@ -17,6 +17,7 @@ module Breakers
     # @option opts [Integer] :seconds_before_retry The number of seconds to wait after an outage begins before testing with a new request
     # @option opts [Integer] :error_threshold The percentage of errors over the last two minutes that indicates an outage
     # @option opts [Integer] :data_retention_seconds The number of seconds to retain success and error data in Redis
+    # @option opts [Proc] :exception_handler A proc taking an exception and returns true if it represents an error on the service
     def initialize(opts)
       @configuration = DEFAULT_OPTS.merge(opts)
     end
@@ -41,6 +42,13 @@ module Breakers
     # @return [Integer] the value
     def seconds_before_retry
       @configuration[:seconds_before_retry]
+    end
+
+    # Returns true if a given exception represents an error with the service
+    #
+    # @return [Boolean] is it an error?
+    def exception_represents_server_error?(exception)
+      @configuration[:exception_handler]&.call(exception)
     end
 
     # Indicate that an error has occurred and potentially create an outage

--- a/lib/breakers/uptime_middleware.rb
+++ b/lib/breakers/uptime_middleware.rb
@@ -69,8 +69,17 @@ module Breakers
           end
         end
       end
+    rescue Faraday::Error::TimeoutError => e
+      handle_error(
+        service: service,
+        request_env: request_env,
+        response_env: nil,
+        error: "#{e.class.name} - #{e.message}",
+        current_outage: current_outage
+      )
+      raise
     rescue => e
-      unless e.is_a?(Breakers::OutageException)
+      if service.exception_represents_server_error?(e)
         handle_error(
           service: service,
           request_env: request_env,

--- a/lib/breakers/version.rb
+++ b/lib/breakers/version.rb
@@ -1,3 +1,3 @@
 module Breakers
-  VERSION = '0.2.2'.freeze
+  VERSION = '0.2.3'.freeze
 end


### PR DESCRIPTION
The immediate problem is that breakers currently treats all exceptions as indications of a service outage, and the code in vets-api raises exceptions for anything in the > 299 status range. This means that outages are being kicked off when they shouldn't. This change stops breakers from handling any exceptions other than Timeout by default but allows the client to specify a callback associated with a service. If that callback returns true for an exception then it will be treated as an indication that a service is having a problem.