### PR TITLE
Fixes for Faraday exceptions. Also, make rubocop happy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,8 @@ AllCops:
   TargetRubyVersion: 2.3
   Include:
     - 'Rakefile'
+  Exclude:
+    - Gemfile
 
 Metrics/LineLength:
   Max: 140
@@ -21,6 +23,9 @@ Metrics/ClassLength:
 
 Metrics/MethodLength:
   Max: 50
+
+Metrics/BlockLength:
+  Max: 500
 
 Metrics/AbcSize:
   Max: 75
@@ -98,7 +103,7 @@ Style/GuardClause:
 Style/Next:
   Enabled: false
 
-Style/IndentArray:
+Layout/IndentArray:
   EnforcedStyle: consistent
 
 # This forces you to change simple if/unless blocks to the conditional form like: `return 2 if badness`.
@@ -149,7 +154,7 @@ Style/WordArray:
 
 # Some people really like to put lines at the beginning and end of class bodies, while other people
 # really don't. It doesn't really seem to matter.
-Style/EmptyLinesAroundClassBody:
+Layout/EmptyLinesAroundClassBody:
   Enabled: false
 
 # This forces you to put a comment like this at the top of every single file:
@@ -164,10 +169,10 @@ Style/Lambda:
   Enabled: false
 
 # Force indentation for milti-line expressions and method calls
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
-Style/MultilineMethodCallIndentation:
+Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
 # This disallows the use of $1, $2 from regular expressions, which seems to make no sense whatsoever
@@ -198,7 +203,7 @@ Style/ZeroLengthPredicate:
 #   ...
 # end
 Lint/EndAlignment:
-  AlignWith: variable
+  EnforcedStyleAlignWith: variable
 
 # This cop will require you to replace or prefix method arguments that go unused with underscores. The problem
 # is that while seeming to solve no problem this could easily cause issues where someone editing the code to

--- a/breakers.gemspec
+++ b/breakers.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'breakers/version'

--- a/lib/breakers/uptime_middleware.rb
+++ b/lib/breakers/uptime_middleware.rb
@@ -69,7 +69,7 @@ module Breakers
           end
         end
       end
-    rescue Faraday::Error::TimeoutError => e
+    rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
       handle_error(
         service: service,
         request_env: request_env,

--- a/spec/example_plugin.rb
+++ b/spec/example_plugin.rb
@@ -1,13 +1,9 @@
 class ExamplePlugin
-  def on_outage_begin(outage)
-  end
+  def on_outage_begin(outage); end
 
-  def on_outage_end(outage)
-  end
+  def on_outage_end(outage); end
 
-  def on_error(service, request_env, response_env)
-  end
+  def on_error(service, request_env, response_env); end
 
-  def on_success(service, request_env, response_env)
-  end
+  def on_success(service, request_env, response_env); end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -141,24 +141,24 @@ describe 'integration suite' do
     it 'adds a failure to redis' do
       begin
         connection.get '/'
-      rescue Faraday::TimeoutError
+      rescue Faraday::ConnectionFailed
       end
       rounded_time = now.to_i - (now.to_i % 60)
       expect(redis.get("VA-errors-#{rounded_time.to_i}").to_i).to eq(1)
     end
 
     it 'raises the exception' do
-      expect { connection.get '/' }.to raise_error(Faraday::TimeoutError)
+      expect { connection.get '/' }.to raise_error(Faraday::ConnectionFailed)
     end
 
     it 'logs the error' do
       expect(logger).to receive(:warn).with(
-        msg: 'Breakers failed request', service: 'VA', url: 'http://va.gov/', error: 'Faraday::TimeoutError - execution expired'
+        msg: 'Breakers failed request', service: 'VA', url: 'http://va.gov/', error: 'Faraday::ConnectionFailed - execution expired'
       )
 
       begin
         connection.get '/'
-      rescue Faraday::TimeoutError
+      rescue Faraday::ConnectionFailed
       end
     end
 
@@ -166,7 +166,7 @@ describe 'integration suite' do
       expect(plugin).to receive(:on_error).with(service, instance_of(Faraday::Env), nil)
       begin
         connection.get '/'
-      rescue Faraday::TimeoutError
+      rescue Faraday::ConnectionFailed
       end
     end
   end


### PR DESCRIPTION
Closes department-of-veterans-affairs/vets.gov-team#4150

This changes the exception type for timeouts to use Faraday::TimeoutError everywhere instead of Faraday::Error::TimeoutError. Honestly I have no idea where the latter exception is defined but it seemed to be working ok. It also seems there's been a change in Faraday where it will raise ConnectionFailed exceptions now for timeouts, or at least the ones I'm simulating in my integration spec. So we're now catching that exception and treating it as an error on the service.

Finally, this fixes issues with rubocop tests in the latest versions of that gem.

If you're wondering, as I was, why these changes occurred when there was no apparent change to Gemfile.lock, it's because that file is included in .gitignore, which seems to be the preference for libraries.