### PR TITLE
add plugin notification on skipped request during outage

### DIFF
--- a/lib/breakers/uptime_middleware.rb
+++ b/lib/breakers/uptime_middleware.rb
@@ -35,6 +35,9 @@ module Breakers
     protected
 
     def outage_response(outage:, service:)
+      Breakers.client.plugins.each do |plugin|
+        plugin.on_skipped_request(service) if plugin.respond_to?(:on_skipped_request)
+      end
       if Breakers.outage_response[:type] == :status_code
         Faraday::Response.new.tap do |response|
           response.finish(

--- a/spec/example_plugin.rb
+++ b/spec/example_plugin.rb
@@ -3,6 +3,8 @@ class ExamplePlugin
 
   def on_outage_end(outage); end
 
+  def on_skipped_request(service); end
+
   def on_error(service, request_env, response_env); end
 
   def on_success(service, request_env, response_env); end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -276,6 +276,14 @@ describe 'integration suite' do
       expect(response.status).to eq(503)
     end
 
+    it 'should tell the plugin about the skipped request during outage' do
+      expect(plugin).to receive(:on_skipped_request).with(service)
+      begin
+        connection.get '/'
+      rescue
+      end
+    end
+
     it 'should include information about the outage in the body' do
       response = connection.get '/'
       expect(response.body).to eq("Outage detected on VA beginning at #{start_time.to_i}")
@@ -306,6 +314,11 @@ describe 'integration suite' do
 
     it 'informs the plugin about the success' do
       expect(plugin).to receive(:on_success).with(service, instance_of(Faraday::Env), instance_of(Faraday::Env))
+      connection.get '/'
+    end
+
+    it 'should not tell the plugin about a skipped request' do
+      expect(plugin).not_to receive(:on_skipped_request)
       connection.get '/'
     end
   end


### PR DESCRIPTION
While looking at metrics around outages, I realized that a potentially useful one would be the number of requests to backend that were skipped or missed while an outage was happening.

This adds support for a plugin to fire on those events.