### PR TITLE
Update Faraday client to latest minor version

### DIFF
--- a/breakers.gemspec
+++ b/breakers.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', ['>= 0.7.4', '< 0.10']
+  spec.add_dependency 'faraday', ['>= 0.7.4', '< 0.18']
   spec.add_dependency 'multi_json', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.0'

--- a/lib/breakers/version.rb
+++ b/lib/breakers/version.rb
@@ -1,3 +1,3 @@
 module Breakers
-  VERSION = '0.2.4'.freeze
+  VERSION = '0.3.0'.freeze
 end


### PR DESCRIPTION
## Background

As part of an effort to reduce technical debt and improve the resiliency of `vets-api`, we would like to upgrade the `faraday` gem to the latest version. 

This repository is a direct dependency of `vets-api` and thus requires upgrading prior to upgrading `vets-api` itself.

See [#2369](https://github.com/department-of-veterans-affairs/va.gov-team/issues/2369) for more information.