### PR TITLE
update UptimeMiddleware to return `duration` in milliseconds

### DIFF
--- a/lib/breakers/uptime_middleware.rb
+++ b/lib/breakers/uptime_middleware.rb
@@ -54,7 +54,7 @@ module Breakers
     def handle_request(service:, request_env:, current_outage: nil)
       start_time = Time.now
       return @app.call(request_env).on_complete do |response_env|
-        response_env[:duration] = Time.now - start_time
+        response_env[:duration] = (Time.now - start_time) * 1000
         if response_env.status >= 500
           handle_error(
             service: service,

--- a/lib/breakers/version.rb
+++ b/lib/breakers/version.rb
@@ -1,3 +1,3 @@
 module Breakers
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.4.0'.freeze
 end


### PR DESCRIPTION
StatsD Exporter now expects time measurements in milliseconds.  
This is in line with how Rails reports time measurements.

update UptimeMiddleware to return `duration` in milliseconds instead of seconds