### PR TITLE
Bump faraday constraint

### DIFF
--- a/breakers.gemspec
+++ b/breakers.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', ['>= 0.7.4', '< 0.18']
+  spec.add_dependency 'faraday', ['>= 0.7.4', '< 2.0']
   spec.add_dependency 'multi_json', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.0'

--- a/lib/breakers/version.rb
+++ b/lib/breakers/version.rb
@@ -1,3 +1,3 @@
 module Breakers
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.5.0'.freeze
 end


### PR DESCRIPTION
## Background

As part of the vets-api major gem upgrades, this PR updates the `faraday` constraint to be `< 2.0`. 

Breakers is a direct dependency of `vets-api` and thus requires upgrading prior to upgrading gems in `vets-api` itself.
Specifically, we need to bump the faraday constraint before we can upgrade the `sentry-raven` gem to the latest major version, which has a faraday dependency of [`>= 1.0` ](https://github.com/getsentry/sentry-ruby/blob/master/sentry-raven/sentry-raven.gemspec#L20)

See [#24620](https://app.zenhub.com/workspaces/vsp---backend-tools-6019ab9387ae890011e05e73/issues/department-of-veterans-affairs/va.gov-team/24620) and [#24430](https://app.zenhub.com/workspaces/vsp---backend-tools-6019ab9387ae890011e05e73/issues/department-of-veterans-affairs/va.gov-team/24430) for further details