### PR TITLE
Fix redis deprecations

### DIFF
--- a/lib/breakers/outage.rb
+++ b/lib/breakers/outage.rb
@@ -132,9 +132,9 @@ module Breakers
     end
 
     def replace_body(body:)
-      Breakers.client.redis_connection.multi do
-        Breakers.client.redis_connection.zrem(key, MultiJson.dump(@body))
-        Breakers.client.redis_connection.zadd(key, start_time.to_i, MultiJson.dump(body))
+      Breakers.client.redis_connection.multi do |pipeline|
+        pipeline.zrem(key, MultiJson.dump(@body))
+        pipeline.zadd(key, start_time.to_i, MultiJson.dump(body))
       end
       @body = body
     end

--- a/lib/breakers/version.rb
+++ b/lib/breakers/version.rb
@@ -1,3 +1,3 @@
 module Breakers
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.6.0'.freeze
 end


### PR DESCRIPTION
```
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

redis.#{method} do
  redis.get("key")
end
should be replaced by:

redis.#{method} do |pipeline|
  pipeline.get("key")
end
```