### PR TITLE
Miscellaneous small fixes

### DIFF
--- a/lib/breakers/service.rb
+++ b/lib/breakers/service.rb
@@ -137,7 +137,7 @@ module Breakers
         end
         start_time += sample_minutes * 60
       end
-      Breakers.client.redis_connection.mget(keys).each_with_index.map do |value, idx|
+      Breakers.client.redis_connection.mget(*keys).each_with_index.map do |value, idx|
         { count: value.to_i, time: times[idx] }
       end
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -390,7 +390,7 @@ describe 'integration suite' do
         expect(response.status).to eq(500)
       end
 
-      it 'updates the last_test_time in the outate' do
+      it 'updates the last_test_time in the outage' do
         connection.get '/'
         expect(service.latest_outage.last_test_time.to_i).to eq(now.to_i)
       end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -41,6 +41,10 @@ describe 'integration suite' do
       stub_request(:get, 'va.gov').to_return(status: 500)
     end
 
+    after do
+      Timecop.return
+    end
+
     it 'adds a failure to redis' do
       connection.get '/'
       rounded_time = now.to_i - (now.to_i % 60)
@@ -136,6 +140,10 @@ describe 'integration suite' do
     before do
       Timecop.freeze(now)
       stub_request(:get, 'va.gov').to_timeout
+    end
+
+    after do
+      Timecop.return
     end
 
     it 'adds a failure to redis' do
@@ -516,6 +524,7 @@ describe 'integration suite' do
   context 'configured to raise exceptions' do
     let(:start_time) { Time.now.utc - 30 }
     let(:now) { Time.now.utc }
+
     before do
       Timecop.freeze(now)
       redis.zadd('VA-outages', start_time.to_i, MultiJson.dump(start_time: start_time.to_i))
@@ -523,6 +532,10 @@ describe 'integration suite' do
 
     before do
       Breakers.outage_response = { type: :exception }
+    end
+
+    after do
+      Timecop.return
     end
 
     it 'raises the exception' do
@@ -536,6 +549,10 @@ describe 'integration suite' do
     before do
       Timecop.freeze(now)
       stub_request(:get, 'va.gov').to_return(status: 200)
+    end
+
+    after do
+      Timecop.return
     end
 
     it 'gives me the request duration' do


### PR DESCRIPTION
## Purpose

In the course of working on https://github.com/department-of-veterans-affairs/breakers/pull/20 , I noticed a few small fixes that could be made. This PR collects them.

## Changes

The commit message for 5cf344ba14197f92645c4ffe5c43db8434aa0b19 explains its purpose: not for the redis gem itself, but for older versions of the mock_redis gem.

Regarding 37ce088131cac28f4fdd55aac696dac419954499, Timecop when not used in block mode requires `Timecop.return` to be called manually to undo its effects. Otherwise its effects are global. This is easily overlooked. It might be appropriate to switch to block-only usage instead, but this commit is the smaller fix.

## Tests

In my local testing, `rake spec` still passes.

## Notes
I'm the author of this work (Jamie McCarthy, @jamiemccarthy) and I'm submitting this PR under the terms of the existing LICENSE.md in this repository.