### PR TITLE
Bump faraday 2.7

### DIFF
--- a/breakers.gemspec
+++ b/breakers.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', ['>= 0.7.4', '< 2.0']
+  spec.add_dependency 'faraday', ['>= 1.2.0', '< 3.0']
   spec.add_dependency 'multi_json', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 11.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '0.43.0'
-  spec.add_development_dependency 'simplecov', '~> 0.12.0'
+  spec.add_development_dependency 'simplecov', '~> 0.12'
   spec.add_development_dependency 'timecop', '~> 0.8.0'
   spec.add_development_dependency 'webmock', '~> 2.1'
 end

--- a/breakers.gemspec
+++ b/breakers.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', ['>= 0.7.4', '< 2.0']
   spec.add_dependency 'multi_json', '~> 1.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.0'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'byebug', '~> 9.0'
   spec.add_development_dependency 'fakeredis', '~> 0.6.0'
   spec.add_development_dependency 'rake', '~> 11.0'

--- a/lib/breakers/version.rb
+++ b/lib/breakers/version.rb
@@ -1,3 +1,3 @@
 module Breakers
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.7.0'.freeze
 end


### PR DESCRIPTION
Bump Faraday dependency to allow vets-api Faraday upgrade to 2.7