### PR TITLE
Feature/service name matching

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,27 @@
+name: Run RSpec Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3.6'
+          bundler-cache: true
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Run RSpec tests
+        run: bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [1.0] - 2025-03-24
+### Added
+- Support matching by service name (#40)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or install it yourself as:
 ```ruby
 service = Breakers::Service.new(
   name: 'messaging',
-  request_matcher: proc { |request_env| request_env.url.host =~ /.*messaging\.va\.gov/ }
+  request_matcher: proc { |breakers_service, request_env, request_service_name| request_env.url.host =~ /.*messaging\.va\.gov/ }
 )
 
 client = Breakers::Client.new(redis_connection: redis, services: [service])
@@ -57,7 +57,7 @@ are defined like this:
 ```ruby
 service = Breakers::Service.new(
   name: 'messaging',
-  request_matcher: proc { |request_env| request_env.url.host =~ /.*messaging\.va\.gov/ },
+  request_matcher: proc { |breakers_service, request_env, request_service_name| breakers_service.name == request_service_name },
   seconds_before_retry: 60,
   error_threshold: 50
 )

--- a/breakers.gemspec
+++ b/breakers.gemspec
@@ -22,11 +22,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'base64', '~> 0.2'
   spec.add_dependency 'faraday', ['>= 1.2.0', '< 3.0']
   spec.add_dependency 'multi_json', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'byebug', '~> 9.0'
+  spec.add_development_dependency 'byebug', '~> 11.1'
   spec.add_development_dependency 'fakeredis', '~> 0.6.0'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/breakers/client.rb
+++ b/lib/breakers/client.rb
@@ -23,6 +23,7 @@ module Breakers
     # Given a request environment, return the service that should handle it.
     #
     # @param request_env [Faraday::Env] the request environment
+    # @param service_name [String] the service name
     # @return [Breakers::Service] the service object
     def service_for_request(request_env:, service_name:)
       @services.find do |service|

--- a/lib/breakers/client.rb
+++ b/lib/breakers/client.rb
@@ -24,9 +24,9 @@ module Breakers
     #
     # @param request_env [Faraday::Env] the request environment
     # @return [Breakers::Service] the service object
-    def service_for_request(request_env:)
+    def service_for_request(request_env:, service_name:)
       @services.find do |service|
-        service.handles_request?(request_env: request_env)
+        service.handles_request?(request_env: request_env, service_name: service_name)
       end
     end
   end

--- a/lib/breakers/service.rb
+++ b/lib/breakers/service.rb
@@ -33,8 +33,8 @@ module Breakers
     #
     # @param request_env [Faraday::Env] the request environment
     # @return [Boolean] should the service handle the request
-    def handles_request?(request_env:)
-      @configuration[:request_matcher].call(request_env)
+    def handles_request?(request_env:, service_name:)
+      @configuration[:request_matcher].call(self, request_env, service_name)
     end
 
     # Get the seconds before retry parameter

--- a/lib/breakers/uptime_middleware.rb
+++ b/lib/breakers/uptime_middleware.rb
@@ -4,9 +4,13 @@ require 'multi_json'
 module Breakers
   # The faraday middleware
   class UptimeMiddleware < Faraday::Middleware
-    def initialize(app, args)
-      @service_name = args[:service_name] || nil
+    def initialize(app, args = nil)
+      @service_name = args&.dig(:service_name)
       super(app)
+    end
+
+    def service_name
+      @service_name
     end
 
     def call(request_env)

--- a/lib/breakers/uptime_middleware.rb
+++ b/lib/breakers/uptime_middleware.rb
@@ -4,7 +4,8 @@ require 'multi_json'
 module Breakers
   # The faraday middleware
   class UptimeMiddleware < Faraday::Middleware
-    def initialize(app)
+    def initialize(app, args)
+      @service_name = args[:service_name] || nil
       super(app)
     end
 
@@ -13,7 +14,7 @@ module Breakers
         return @app.call(request_env)
       end
 
-      service = Breakers.client.service_for_request(request_env: request_env)
+      service = Breakers.client.service_for_request(request_env: request_env, service_name: @service_name)
 
       if !service
         return @app.call(request_env)

--- a/lib/breakers/version.rb
+++ b/lib/breakers/version.rb
@@ -1,3 +1,3 @@
 module Breakers
-  VERSION = '0.7.1'.freeze
+  VERSION = '1.0'.freeze
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -23,7 +23,7 @@ describe 'integration suite' do
   end
   let(:connection) do
     Faraday.new('http://va.gov') do |conn|
-      conn.use :breakers
+      conn.use(:breakers, service_name: 'VA')
       conn.adapter Faraday.default_adapter
     end
   end
@@ -412,6 +412,45 @@ describe 'integration suite' do
       response = connection.get('http://whitehouse.gov')
       expect(response.status).to eq(200)
       expect(response.body).to eq('POTUS')
+    end
+  end
+
+  context 'requests may be matched by service name' do
+    let(:alternate_connection) do
+      Faraday.new('http://va.gov') do |conn|
+        conn.use(:breakers, service_name: 'ALTERNATE')
+        conn.adapter Faraday.default_adapter
+      end
+    end
+    let(:now) { Time.now.utc }
+    let(:matcher) do
+      proc do |breakers_service, request_env, request_service_name|
+        breakers_service.name == request_service_name
+      end
+    end
+    let(:service) do
+      Breakers::Service.new(
+        name: 'VA',
+        request_matcher: matcher,
+        seconds_before_retry: 60,
+        error_threshold: 50,
+        exception_handler: proc { |e| true }
+      )
+    end
+
+    before do
+      Timecop.freeze(now)
+      stub_request(:get, 'http://fda.gov').to_return(status: 500)
+    end
+
+    it 'matches by service name' do
+      response = connection.get('http://fda.gov')
+      expect(service.latest_outage).to be
+    end
+
+    it 'different service does not match' do
+      response = alternate_connection.get('http://fda.gov')
+      expect(service.latest_outage).not_to be
     end
   end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -6,7 +6,7 @@ describe 'integration suite' do
   let(:service) do
     Breakers::Service.new(
       name: 'VA',
-      request_matcher: proc { |request_env| request_env.url.host =~ /.*va.gov/ },
+      request_matcher: proc { |breakers_service, request_env, request_service_name| request_env.url.host =~ /.*va.gov/ },
       seconds_before_retry: 60,
       error_threshold: 50
     )
@@ -217,7 +217,7 @@ describe 'integration suite' do
       let(:service) do
         Breakers::Service.new(
           name: 'VA',
-          request_matcher: proc { |request_env| request_env.url.host =~ /.*va.gov/ },
+          request_matcher: proc { |breakers_service, request_env, request_service_name| request_env.url.host =~ /.*va.gov/ },
           seconds_before_retry: 60,
           error_threshold: 50,
           exception_handler: proc { |e| true }


### PR DESCRIPTION
This PR updates breakers to allow receiving a service name and pass it on to the request matcher. It also brings some gems up to date and adds a GH action to run the specs.

See: https://github.com/department-of-veterans-affairs/vets-api/pull/21368


Dependency updates:

* [`breakers.gemspec`](diffhunk://#diff-1f8862690516c805d9e4215cd24c87dfbaa936b8f4c6319ae3c57833353fdda9R25-R30): Added a new dependency on the `base64` gem and updated the `byebug` development dependency to version `11.1`.

Enhancements to method signatures:

* [`lib/breakers/client.rb`](diffhunk://#diff-93ec09ce49a18e885ceebfa5bbf36ec788f2c1255253d9fa903f22a83d1a5deeR26-R30): Modified the `service_for_request` method to include an additional `service_name` parameter.
* [`lib/breakers/service.rb`](diffhunk://#diff-1e33441c5ae22b13be15d1194f26663651c828f2b83044ecd1b9e02e94be6a18L36-R37): Updated the `handles_request?` method to accept a `service_name` parameter and pass it to the request matcher.
* [`lib/breakers/uptime_middleware.rb`](diffhunk://#diff-fc2e41293ea49df6070a7c9ade9083be7566c01c34db7b6ef2eb8918f9111b81L7-R21): Updated the `initialize` method to accept `args` and extract `service_name`, and modified the `call` method to pass `service_name` to `service_for_request`.

Test updates:

* [`spec/integration_spec.rb`](diffhunk://#diff-800588e3890bf8789d164579d3f87b2a5a8ee384fbea341a0e2e84ab52e887aaL9-R9): Updated existing tests to use the new `service_name` parameter in the request matcher, and added new tests to verify matching by service name [[1]](diffhunk://#diff-800588e3890bf8789d164579d3f87b2a5a8ee384fbea341a0e2e84ab52e887aaL9-R9) [[2]](diffhunk://#diff-800588e3890bf8789d164579d3f87b2a5a8ee384fbea341a0e2e84ab52e887aaL26-R26) [[3]](diffhunk://#diff-800588e3890bf8789d164579d3f87b2a5a8ee384fbea341a0e2e84ab52e887aaL220-R220) [[4]](diffhunk://#diff-800588e3890bf8789d164579d3f87b2a5a8ee384fbea341a0e2e84ab52e887aaR418-R456).

CI/CD improvements:

* [`.github/workflows/rspec.yml`](diffhunk://#diff-1fadaba7942eb03a370984f465dc59789417e580083e4bcaa2d073959b1815beR1-R27): Added a new GitHub Actions workflow to run RSpec tests on pushes to the `main` branch and on pull requests.